### PR TITLE
Set the correct hashing method for exporting users

### DIFF
--- a/includes/lib/kinde-auth-wordpress-export.php
+++ b/includes/lib/kinde-auth-wordpress-export.php
@@ -61,7 +61,7 @@ class Kinde_Auth_Wordpress_Export
                     'salt' => substr($user_data->user_pass, 4, 8),
                     'salt_position' => 'prefix',
                     'hashed_password' => $user_data->user_pass,
-                    'hashing_method' => 'brcypt',
+                    'hashing_method' => 'wordpress',
                     'email_verified' => $user_data->user_status == "0" ? "true" : "false"
                 ];
 


### PR DESCRIPTION
# Explain your changes

Set the correct hashing method for exporting users. Wordpress uses a custom hash algorithm, which can be imported into Kinde using the 'wordpress' hashing algorithm.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the user data export process to use the WordPress hashing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->